### PR TITLE
Read/Write to storage i2c assert

### DIFF
--- a/examples/demos/decentralized_swarm/src/common_files/persistant_log.c
+++ b/examples/demos/decentralized_swarm/src/common_files/persistant_log.c
@@ -58,6 +58,11 @@ static uint32_t persistentTotalFlightTime_ms = 12000;
 
 static uint8_t resetData = 0;
 static bool pendingStorageWrite = false;
+static TaskHandle_t storageTaskHandle = NULL;
+
+void setStorageTaskHandle(TaskHandle_t handle) {
+    storageTaskHandle = handle;
+}
 
 static const char* PERSISTENT_FLIGHT_COUNT_STORAGE_KEY = "app/totFlight";
 static const char* PERSISTENT_FLIGHT_TIME_STORAGE_KEY = "app/totTime";
@@ -95,8 +100,11 @@ void getTotalFlightsFromStorage() {
 
 static void resetDataCallback() {
      persistentFlightCount = 0;
-     persistentTotalFlightTime_ms = 0.0f;
-     storeTotalFlights();
+     persistentTotalFlightTime_ms = 0;
+     pendingStorageWrite = true;
+     if (storageTaskHandle) {
+         xTaskNotifyGive(storageTaskHandle);
+     }
 }
 
 void updateAliveTime() {
@@ -119,6 +127,9 @@ void updateFlightTime() {
      totalFlightTime_ms += lastFlightTime_ms;
      persistentTotalFlightTime_ms += lastFlightTime_ms;
      pendingStorageWrite = true;
+     if (storageTaskHandle) {
+         xTaskNotifyGive(storageTaskHandle);
+     }
 }
 
 

--- a/examples/demos/decentralized_swarm/src/common_files/persistant_log.c
+++ b/examples/demos/decentralized_swarm/src/common_files/persistant_log.c
@@ -57,6 +57,7 @@ static uint32_t totalFlightTime_ms = 0;
 static uint32_t persistentTotalFlightTime_ms = 12000;
 
 static uint8_t resetData = 0;
+static bool pendingStorageWrite = false;
 
 static const char* PERSISTENT_FLIGHT_COUNT_STORAGE_KEY = "app/totFlight";
 static const char* PERSISTENT_FLIGHT_TIME_STORAGE_KEY = "app/totTime";
@@ -71,12 +72,16 @@ static void msToHumanTime(const uint32_t time_ms, humanTime_t* humanTime) {
     humanTime->s = time_s;
 }
 
-static void storeTotalFlights() {
+void storeTotalFlights() {
+    if (!pendingStorageWrite) {
+        return;
+    }
     storageStore(PERSISTENT_FLIGHT_COUNT_STORAGE_KEY, &persistentFlightCount, sizeof(uint32_t));
     storageStore(PERSISTENT_FLIGHT_TIME_STORAGE_KEY, &persistentTotalFlightTime_ms, sizeof(uint32_t));
     humanTime_t totalTimeHt;
     msToHumanTime(persistentTotalFlightTime_ms, &totalTimeHt);
     DEBUG_PRINT("Stored flight time %lu:%lu:%lu, flights %lu\n", totalTimeHt.h, totalTimeHt.m, totalTimeHt.s, persistentFlightCount);
+    pendingStorageWrite = false;
 }
 
 void getTotalFlightsFromStorage() {
@@ -113,7 +118,7 @@ void updateFlightTime() {
      lastFlightTime_ms = alive_time_ms - takeOffTime_ms;
      totalFlightTime_ms += lastFlightTime_ms;
      persistentTotalFlightTime_ms += lastFlightTime_ms;
-     storeTotalFlights();
+     pendingStorageWrite = true;
 }
 
 

--- a/examples/demos/decentralized_swarm/src/common_files/persistant_log.h
+++ b/examples/demos/decentralized_swarm/src/common_files/persistant_log.h
@@ -29,3 +29,4 @@ void updateTakeOffTime();
 void updateFlightTime();
 void getTotalFlightsFromStorage();
 void storeTotalFlights();
+void setStorageTaskHandle(TaskHandle_t handle);

--- a/examples/demos/decentralized_swarm/src/common_files/persistant_log.h
+++ b/examples/demos/decentralized_swarm/src/common_files/persistant_log.h
@@ -28,3 +28,4 @@ void updateAliveTime();
 void updateTakeOffTime();
 void updateFlightTime();
 void getTotalFlightsFromStorage();
+void storeTotalFlights();

--- a/examples/demos/decentralized_swarm/src/pilot.c
+++ b/examples/demos/decentralized_swarm/src/pilot.c
@@ -500,6 +500,11 @@ void appMain()
     xTimerStart(stateTransitionTimer, 20);
 
     isInit = true;
+
+    while (1) {
+        vTaskDelay(M2T(2000));
+        storeTotalFlights();
+    }
 }
 
 LOG_GROUP_START(app)

--- a/examples/demos/decentralized_swarm/src/pilot.c
+++ b/examples/demos/decentralized_swarm/src/pilot.c
@@ -501,8 +501,9 @@ void appMain()
 
     isInit = true;
 
+    setStorageTaskHandle(xTaskGetCurrentTaskHandle());
     while (1) {
-        vTaskDelay(M2T(2000));
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
         storeTotalFlights();
     }
 }

--- a/src/drivers/src/eeprom.c
+++ b/src/drivers/src/eeprom.c
@@ -138,23 +138,40 @@ bool eepromTestConnection(void)
 
 bool eepromReadBuffer(uint8_t* buffer, uint16_t readAddr, uint16_t len)
 {
-  bool status;
+  // Use a static intermediate buffer to ensure DMA-safe memory is used,
+  // since callers may run from tasks with CCM stacks (not DMA-accessible).
+  static uint8_t dmaBuffer[32];
+  uint16_t offset = 0;
 
   if ((uint32_t)readAddr + len > EEPROM_SIZE)
   {
      return false;
   }
 
-  status = i2cdevRead16(I2Cx, devAddr, readAddr, len, buffer);
+  while (offset < len) {
+    uint16_t chunkLen = len - offset;
+    if (chunkLen > sizeof(dmaBuffer)) {
+      chunkLen = sizeof(dmaBuffer);
+    }
 
-  return status;
+    bool status = i2cdevRead16(I2Cx, devAddr, readAddr + offset, chunkLen, dmaBuffer);
+    if (!status) {
+      return false;
+    }
+
+    memcpy(buffer + offset, dmaBuffer, chunkLen);
+    offset += chunkLen;
+  }
+
+  return true;
 }
 
 bool eepromWriteBuffer(const uint8_t* buffer, uint16_t writeAddr, uint16_t len)
 {
   bool status;
 
-  unsigned char pageBuffer[32];
+  // Static to ensure DMA-safe memory; callers may run from tasks with CCM stacks.
+  static unsigned char pageBuffer[32];
   int bufferIndex = 0;
   int leftToWrite = len;
   uint16_t currentAddress = writeAddr;
@@ -188,7 +205,7 @@ bool eepromWriteBuffer(const uint8_t* buffer, uint16_t writeAddr, uint16_t len)
 
     // Waiting for page to be written
     for (int retry = 0; retry < 30; retry++) {
-      uint8_t dummy;
+      static uint8_t dummy; // static = DMA-safe; not used as data, just for ACK polling
       status = i2cdevWrite(I2Cx, devAddr, 1, &dummy);
 
       if (status) {

--- a/src/drivers/src/eeprom.c
+++ b/src/drivers/src/eeprom.c
@@ -138,40 +138,23 @@ bool eepromTestConnection(void)
 
 bool eepromReadBuffer(uint8_t* buffer, uint16_t readAddr, uint16_t len)
 {
-  // Use a static intermediate buffer to ensure DMA-safe memory is used,
-  // since callers may run from tasks with CCM stacks (not DMA-accessible).
-  static uint8_t dmaBuffer[32];
-  uint16_t offset = 0;
+  bool status;
 
   if ((uint32_t)readAddr + len > EEPROM_SIZE)
   {
      return false;
   }
 
-  while (offset < len) {
-    uint16_t chunkLen = len - offset;
-    if (chunkLen > sizeof(dmaBuffer)) {
-      chunkLen = sizeof(dmaBuffer);
-    }
+  status = i2cdevRead16(I2Cx, devAddr, readAddr, len, buffer);
 
-    bool status = i2cdevRead16(I2Cx, devAddr, readAddr + offset, chunkLen, dmaBuffer);
-    if (!status) {
-      return false;
-    }
-
-    memcpy(buffer + offset, dmaBuffer, chunkLen);
-    offset += chunkLen;
-  }
-
-  return true;
+  return status;
 }
 
 bool eepromWriteBuffer(const uint8_t* buffer, uint16_t writeAddr, uint16_t len)
 {
   bool status;
 
-  // Static to ensure DMA-safe memory; callers may run from tasks with CCM stacks.
-  static unsigned char pageBuffer[32];
+  unsigned char pageBuffer[32];
   int bufferIndex = 0;
   int leftToWrite = len;
   uint16_t currentAddress = writeAddr;
@@ -205,7 +188,7 @@ bool eepromWriteBuffer(const uint8_t* buffer, uint16_t writeAddr, uint16_t len)
 
     // Waiting for page to be written
     for (int retry = 0; retry < 30; retry++) {
-      static uint8_t dummy; // static = DMA-safe; not used as data, just for ACK polling
+      uint8_t dummy;
       status = i2cdevWrite(I2Cx, devAddr, 1, &dummy);
 
       if (status) {


### PR DESCRIPTION
The i2c asserts (crazyflie-firmware-experimental/src/drivers/src/i2c_drv.c:390) when reading/writing to the storage of the Crazyflie should be fixed in [this PR](https://github.com/bitcraze/crazyflie-firmware/pull/1609) of the crazyflie-firmware.

With that fix, the Crazyflies couldn't take off after landing once. This was caused by `updateFlightTime()` being called from `stateTransition()`, which is a timer callback and this blocked the timer service task. 
To prevent that, I added  a FreeRTOS task notification for storage writes and `appMain` now blocks on `ulTaskNotifyTake`. `updateFlightTime` and `resetDataCallback` notify the task directly, triggering the EEPROM write immediately after landing.